### PR TITLE
fix toast listener registration

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -177,7 +177,7 @@ function useToast() {
 				listeners.splice(index, 1)
 			}
 		}
-	}, [state])
+        }, [])
 
 	return {
 		...state,


### PR DESCRIPTION
## Summary
- avoid stacking toast listeners by registering only once

## Testing
- `npm run lint`
- `node -r ts-node/register <<'NODE'
const React = require('react');
const TestRenderer = require('react-test-renderer');
const { toast, useToast } = require('./hooks/use-toast');
let renders = 0;
function TestComponent(){
  useToast();
  renders++;
  return null;
}
TestRenderer.act(() => { TestRenderer.create(React.createElement(TestComponent)); });
console.log('renders after mount', renders);
TestRenderer.act(() => { toast({ title: 'test1' }); });
console.log('renders after toast1', renders);
TestRenderer.act(() => { toast({ title: 'test2' }); });
console.log('renders after toast2', renders);
NODE`

------
https://chatgpt.com/codex/tasks/task_b_68910ae928d88326b3fe5ec123ff6848