### PR TITLE
feat(i18n): add French resume subtitles

### DIFF
--- a/data/i18n/fr.ts
+++ b/data/i18n/fr.ts
@@ -34,21 +34,24 @@ export const fr = {
 	resume: {
 		title: "CV",
 		subtitle: "Mon parcours professionnel et mes qualifications",
-		education: {
-			title: "Formation",
-			degree: "Diplôme",
-			institution: "Institution",
-		},
-		experience: {
-			title: "Expérience",
-			current: "Actuel",
-			type: {
-				fullTime: "Temps plein",
-				intern: "Stage",
-			},
-		},
-		certificates: {
-			title: "Certificats",
-		},
-	},
+                education: {
+                        title: "Formation",
+                        subtitle: "Voici quelques-unes de mes formations",
+                        degree: "Diplôme",
+                        institution: "Institution",
+                },
+                experience: {
+                        title: "Expérience",
+                        subtitle: "Voici quelques-unes de mes expériences",
+                        current: "Actuel",
+                        type: {
+                                fullTime: "Temps plein",
+                                intern: "Stage",
+                        },
+                },
+                certificates: {
+                        title: "Certificats",
+                        subtitle: "Voici quelques-uns de mes certificats",
+                },
+        },
 }


### PR DESCRIPTION
## Summary
- add French subtitles to resume education, experience, and certificate sections

## Testing
- `npx --yes ts-node -e "const { fr } = require('./data/i18n/fr'); console.log(fr.resume.education.subtitle); console.log(fr.resume.experience.subtitle); console.log(fr.resume.certificates.subtitle);"`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68910aea08848326bb0f21d8c810dde9